### PR TITLE
Fix in-class initialization of const floats

### DIFF
--- a/include/private/meta/compressor.h
+++ b/include/private/meta/compressor.h
@@ -32,81 +32,81 @@ namespace lsp
     {
         struct compressor_metadata
         {
-            static const float  ATTACK_LVL_MIN          = GAIN_AMP_M_60_DB;
-            static const float  ATTACK_LVL_MAX          = GAIN_AMP_0_DB;
-            static const float  ATTACK_LVL_DFL          = GAIN_AMP_M_12_DB;
-            static const float  ATTACK_LVL_STEP         = 0.05f;
+            static constexpr float  ATTACK_LVL_MIN          = GAIN_AMP_M_60_DB;
+            static constexpr float  ATTACK_LVL_MAX          = GAIN_AMP_0_DB;
+            static constexpr float  ATTACK_LVL_DFL          = GAIN_AMP_M_12_DB;
+            static constexpr float  ATTACK_LVL_STEP         = 0.05f;
 
-            static const float  RELEASE_LVL_MIN         = GAIN_AMP_M_INF_DB;
-            static const float  RELEASE_LVL_MAX         = GAIN_AMP_0_DB;
-            static const float  RELEASE_LVL_DFL         = GAIN_AMP_M_INF_DB;
-            static const float  RELEASE_LVL_STEP        = 0.05f;
+            static constexpr float  RELEASE_LVL_MIN         = GAIN_AMP_M_INF_DB;
+            static constexpr float  RELEASE_LVL_MAX         = GAIN_AMP_0_DB;
+            static constexpr float  RELEASE_LVL_DFL         = GAIN_AMP_M_INF_DB;
+            static constexpr float  RELEASE_LVL_STEP        = 0.05f;
 
-            static const float  ATTACK_TIME_MIN         = 0.0f;
-            static const float  ATTACK_TIME_MAX         = 2000.0f;
-            static const float  ATTACK_TIME_DFL         = 20.0f;
-            static const float  ATTACK_TIME_STEP        = 0.0025f;
+            static constexpr float  ATTACK_TIME_MIN         = 0.0f;
+            static constexpr float  ATTACK_TIME_MAX         = 2000.0f;
+            static constexpr float  ATTACK_TIME_DFL         = 20.0f;
+            static constexpr float  ATTACK_TIME_STEP        = 0.0025f;
 
-            static const float  RELEASE_TIME_MIN        = 0.0f;
-            static const float  RELEASE_TIME_MAX        = 5000.0f;
-            static const float  RELEASE_TIME_DFL        = 100.0f;
-            static const float  RELEASE_TIME_STEP       = 0.0025f;
+            static constexpr float  RELEASE_TIME_MIN        = 0.0f;
+            static constexpr float  RELEASE_TIME_MAX        = 5000.0f;
+            static constexpr float  RELEASE_TIME_DFL        = 100.0f;
+            static constexpr float  RELEASE_TIME_STEP       = 0.0025f;
 
-            static const float  KNEE_MIN                = GAIN_AMP_M_24_DB;
-            static const float  KNEE_MAX                = GAIN_AMP_0_DB;
-            static const float  KNEE_DFL                = GAIN_AMP_M_6_DB;
-            static const float  KNEE_STEP               = 0.01f;
+            static constexpr float  KNEE_MIN                = GAIN_AMP_M_24_DB;
+            static constexpr float  KNEE_MAX                = GAIN_AMP_0_DB;
+            static constexpr float  KNEE_DFL                = GAIN_AMP_M_6_DB;
+            static constexpr float  KNEE_STEP               = 0.01f;
 
-            static const float  BTH_MIN                 = GAIN_AMP_M_120_DB;
-            static const float  BTH_MAX                 = GAIN_AMP_M_60_DB;
-            static const float  BTH_DFL                 = GAIN_AMP_M_72_DB;
-            static const float  BTH_STEP                = 0.05f;
+            static constexpr float  BTH_MIN                 = GAIN_AMP_M_120_DB;
+            static constexpr float  BTH_MAX                 = GAIN_AMP_M_60_DB;
+            static constexpr float  BTH_DFL                 = GAIN_AMP_M_72_DB;
+            static constexpr float  BTH_STEP                = 0.05f;
 
-            static const float  BSA_MIN                 = GAIN_AMP_0_DB;
-            static const float  BSA_MAX                 = GAIN_AMP_P_72_DB;
-            static const float  BSA_DFL                 = GAIN_AMP_P_6_DB;
-            static const float  BSA_STEP                = 0.05f;
+            static constexpr float  BSA_MIN                 = GAIN_AMP_0_DB;
+            static constexpr float  BSA_MAX                 = GAIN_AMP_P_72_DB;
+            static constexpr float  BSA_DFL                 = GAIN_AMP_P_6_DB;
+            static constexpr float  BSA_STEP                = 0.05f;
 
-            static const float  MAKEUP_MIN              = GAIN_AMP_M_60_DB;
-            static const float  MAKEUP_MAX              = GAIN_AMP_P_60_DB;
-            static const float  MAKEUP_DFL              = GAIN_AMP_0_DB;
-            static const float  MAKEUP_STEP             = 0.05f;
+            static constexpr float  MAKEUP_MIN              = GAIN_AMP_M_60_DB;
+            static constexpr float  MAKEUP_MAX              = GAIN_AMP_P_60_DB;
+            static constexpr float  MAKEUP_DFL              = GAIN_AMP_0_DB;
+            static constexpr float  MAKEUP_STEP             = 0.05f;
 
-            static const float  RATIO_MIN               = 1.0f;
-            static const float  RATIO_MAX               = 100.0f;
-            static const float  RATIO_DFL               = 4.0f;
-            static const float  RATIO_STEP              = 0.0025f;
+            static constexpr float  RATIO_MIN               = 1.0f;
+            static constexpr float  RATIO_MAX               = 100.0f;
+            static constexpr float  RATIO_DFL               = 4.0f;
+            static constexpr float  RATIO_STEP              = 0.0025f;
 
-            static const float  LOOKAHEAD_MIN           = 0.0f;
-            static const float  LOOKAHEAD_MAX           = 20.0f;
-            static const float  LOOKAHEAD_DFL           = 0.0f;
-            static const float  LOOKAHEAD_STEP          = 0.01f;
+            static constexpr float  LOOKAHEAD_MIN           = 0.0f;
+            static constexpr float  LOOKAHEAD_MAX           = 20.0f;
+            static constexpr float  LOOKAHEAD_DFL           = 0.0f;
+            static constexpr float  LOOKAHEAD_STEP          = 0.01f;
 
-            static const float  REACTIVITY_MIN          = 0.000;    // Minimum reactivity [ms]
-            static const float  REACTIVITY_MAX          = 250;      // Maximum reactivity [ms]
-            static const float  REACTIVITY_DFL          = 10;       // Default reactivity [ms]
-            static const float  REACTIVITY_STEP         = 0.025;    // Reactivity step
+            static constexpr float  REACTIVITY_MIN          = 0.000;    // Minimum reactivity [ms]
+            static constexpr float  REACTIVITY_MAX          = 250;      // Maximum reactivity [ms]
+            static constexpr float  REACTIVITY_DFL          = 10;       // Default reactivity [ms]
+            static constexpr float  REACTIVITY_STEP         = 0.025;    // Reactivity step
 
-            static const size_t SC_MODE_DFL             = 1;
-            static const size_t SC_SOURCE_DFL           = 0;
-            static const size_t SC_TYPE_DFL             = 0;
+            static const size_t SC_MODE_DFL                 = 1;
+            static const size_t SC_SOURCE_DFL               = 0;
+            static const size_t SC_TYPE_DFL                 = 0;
 
-            static const float  HPF_MIN                 = 10.0f;
-            static const float  HPF_MAX                 = 20000.0f;
-            static const float  HPF_DFL                 = 10.0f;
-            static const float  HPF_STEP                = 0.0025f;
+            static constexpr float  HPF_MIN                 = 10.0f;
+            static constexpr float  HPF_MAX                 = 20000.0f;
+            static constexpr float  HPF_DFL                 = 10.0f;
+            static constexpr float  HPF_STEP                = 0.0025f;
 
-            static const float  LPF_MIN                 = 10.0f;
-            static const float  LPF_MAX                 = 20000.0f;
-            static const float  LPF_DFL                 = 20000.0f;
-            static const float  LPF_STEP                = 0.0025f;
+            static constexpr float  LPF_MIN                 = 10.0f;
+            static constexpr float  LPF_MAX                 = 20000.0f;
+            static constexpr float  LPF_DFL                 = 20000.0f;
+            static constexpr float  LPF_STEP                = 0.0025f;
 
-            static const size_t CURVE_MESH_SIZE         = 256;
-            static const float  CURVE_DB_MIN            = -72;
-            static const float  CURVE_DB_MAX            = +24;
+            static const size_t CURVE_MESH_SIZE             = 256;
+            static constexpr float  CURVE_DB_MIN            = -72;
+            static constexpr float  CURVE_DB_MAX            = +24;
 
-            static const size_t TIME_MESH_SIZE          = 400;
-            static const float  TIME_HISTORY_MAX        = 5.0f;
+            static const size_t TIME_MESH_SIZE              = 400;
+            static constexpr float  TIME_HISTORY_MAX        = 5.0f;
 
             enum mode_t
             {
@@ -115,7 +115,7 @@ namespace lsp
                 CM_BOOSTING
             };
 
-            static const size_t CM_DEFAULT              = CM_DOWNWARD;
+            static const size_t CM_DEFAULT                  = CM_DOWNWARD;
         };
 
         extern const meta::plugin_t compressor_mono;


### PR DESCRIPTION
include/private/meta/compressor.h:
Change all in-class initializers of static float members to use
constexpr, which is compatible with C++11.

Relates to https://github.com/sadko4u/lsp-plugins/issues/257